### PR TITLE
Fix problem that serviceaccount don't have enough permissions to read configmaps.

### DIFF
--- a/bookstore-kubernetes-manifests/bookstore-role.yml
+++ b/bookstore-kubernetes-manifests/bookstore-role.yml
@@ -4,7 +4,7 @@ metadata:
   name: book-admin-role
   namespace: bookstore-microservices
 rules:
-  - apiGroups: [""]
+  - apiGroups: ["", "extensions", "apps"]
     resources:
       - namespaces
       - endpoints

--- a/bookstore.yml
+++ b/bookstore.yml
@@ -17,6 +17,8 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - "extensions"
+  - "app"
   resources:
   - namespaces
   - endpoints


### PR DESCRIPTION
> 2022-06-08 16:36:16.418  WARN 1 --- [           main] o.s.c.k.config.ConfigMapPropertySource   : Can't read configMap with name: [payment] in namespace:[bookstore-microservices]. Ignoring.
> 
> io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: https://172.21.0.1/api/v1/namespaces/bookstore-microservices/configmaps/payment. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. configmaps "payment" is forbidden: User "system:serviceaccount:bookstore-microservices:book-admin" cannot get resource "configmaps" in API group "" in the namespace "bookstore-microservices".

![image](https://user-images.githubusercontent.com/40296002/172781840-efd8928d-0e1a-406e-85d8-0b11e8e8afad.png)
